### PR TITLE
Fix V645 warning from PVS-Studio Static Analyzer

### DIFF
--- a/src/population.cpp
+++ b/src/population.cpp
@@ -164,11 +164,11 @@ Population::Population(const char *filename) {
 				{
 					// If we've started to form the metadata, put a space in the front
 					if(md) {
-						strncat(metadata, " ", 128 - strlen(metadata));
+                                                strncat(metadata, " ", 128 - 1 - strlen(metadata));
 					}
 
 					// Append the next word to the metadata, and say that there is metadata
-					strncat(metadata, curword, 128 - strlen(metadata));
+                                        strncat(metadata, curword, 128 - 1 - strlen(metadata));
 					md = true;
 
 					//strcpy(curword, NEAT::getUnit(curline, curwordnum++, delimiters));


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
[V645](https://www.viva64.com/en/w/v645/) The 'strncat' function call could lead to the 'metadata' buffer overflow.
The bounds should not contain the size of the buffer, but a number of
characters it can hold.