### PR TITLE
Fix V599 warning from PVS-Studio Static Analyzer

### DIFF
--- a/include/experiments.h
+++ b/include/experiments.h
@@ -59,6 +59,7 @@ int pole2_epoch(Population *pop,int generation,char *filename,bool velocity, Car
 class CartPole {
 public:
   CartPole(bool randomize,bool velocity);
+  virtual ~CartPole() {}
   virtual void simplifyTask();  
   virtual void nextTask();
   virtual double evalNet(Network *net,int thresh);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
[V599](https://www.viva64.com/en/w/v599/) The virtual destructor is not present, although the 'CartPole' class
contains virtual functions.