### PR TITLE
changed some consts to constexprs for modern g++ compilers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@
 # Temporary files
 *~
 
+# The "neat" executable
+neat
+
+# Any 'gen_' output files
+gen_*

--- a/include/experiments.h
+++ b/include/experiments.h
@@ -84,23 +84,23 @@ private:
   bool outsideBounds(); 
 
   const static int NUM_INPUTS=7;
-  const static double MUP = 0.000002;
-  const static double MUC = 0.0005;
-  const static double GRAVITY= -9.8;
-  const static double MASSCART= 1.0;
-  const static double MASSPOLE_1= 0.1;
+  constexpr static double MUP = 0.000002;
+  constexpr static double MUC = 0.0005;
+  constexpr static double GRAVITY= -9.8;
+  constexpr static double MASSCART= 1.0;
+  constexpr static double MASSPOLE_1= 0.1;
 
-  const static double LENGTH_1= 0.5;		  /* actually half the pole's length */
+  constexpr static double LENGTH_1= 0.5;		  /* actually half the pole's length */
 
-  const static double FORCE_MAG= 10.0;
-  const static double TAU= 0.01;		  //seconds between state updates 
+  constexpr static double FORCE_MAG= 10.0;
+  constexpr static double TAU= 0.01;		  //seconds between state updates 
 
-  const static double one_degree= 0.0174532;	/* 2pi/360 */
-  const static double six_degrees= 0.1047192;
-  const static double twelve_degrees= 0.2094384;
-  const static double fifteen_degrees= 0.2617993;
-  const static double thirty_six_degrees= 0.628329;
-  const static double fifty_degrees= 0.87266;
+  constexpr static double one_degree= 0.0174532;	/* 2pi/360 */
+  constexpr static double six_degrees= 0.1047192;
+  constexpr static double twelve_degrees= 0.2094384;
+  constexpr static double fifteen_degrees= 0.2617993;
+  constexpr static double thirty_six_degrees= 0.628329;
+  constexpr static double fifty_degrees= 0.87266;
 
   double LENGTH_2;
   double MASSPOLE_2;


### PR DESCRIPTION
Made these changes and ran `.neat test.ne` fine 